### PR TITLE
JNG-4247 Add backtick to timestamp and date object

### DIFF
--- a/Syntaxes/jsl.tmLanguage
+++ b/Syntaxes/jsl.tmLanguage
@@ -542,6 +542,14 @@
 					<string>string.quoted.double.states</string>
 				</dict>
 				<dict>
+					<key>begin</key>
+					<string>\`</string>
+					<key>end</key>
+					<string>\`</string>
+					<key>name</key>
+					<string>string.quoted.double.states</string>
+				</dict>
+				<dict>
 					<key>match</key>
 					<string>\b\\b</string>
 					<key>name</key>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4247" title="JNG-4247" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4247</a>  Backticked language elements are not highlighted correctly for JSL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
